### PR TITLE
add except in sabdab

### DIFF
--- a/diffab/datasets/sabdab.py
+++ b/diffab/datasets/sabdab.py
@@ -139,8 +139,13 @@ def preprocess_sabdab_structure(task):
     pdb_path = task['pdb_path']
 
     parser = PDB.PDBParser(QUIET=True)
-    model = parser.get_structure(id, pdb_path)[0]
-
+    
+    try:
+        model = parser.get_structure(id, pdb_path)[0]
+    except Exception as e:
+        logging.warning(f'Failed to parse {pdb_path}: {e}')
+        return None
+    
     parsed = {
         'id': entry['id'],
         'heavy': None,


### PR DESCRIPTION
some proteins are too long for Biopython to deal with. Add `exception` to override these .pdb files.